### PR TITLE
Clarify attribute order error for embed templates

### DIFF
--- a/lib/phoenix_component/declarative.ex
+++ b/lib/phoenix_component/declarative.ex
@@ -1082,12 +1082,20 @@ defmodule Phoenix.Component.Declarative do
       with [%{line: first_attr_line} | _] <- attrs do
         compile_error!(first_attr_line, env.file, """
         attributes must be defined before the first function clause at line #{meta[:line]}
+
+        This can happen when both the #{name}/1 component function and a template
+        of the same name are defined. Templates can still declare attributes and
+        slots, but the related function must be defined without a body.
         """)
       end
 
       with [%{line: first_slot_line} | _] <- slots do
         compile_error!(first_slot_line, env.file, """
         slots must be defined before the first function clause at line #{meta[:line]}
+
+        This can happen when both the #{name}/1 component function and a template
+        of the same name are defined. Templates can still declare attributes and
+        slots, but the related function must be defined without a body.
         """)
       end
     end


### PR DESCRIPTION
## Summary
- improve error message when attributes and slots come after the first function clause

## Testing
- `mix test` *(fails: `bash: mix: command not found`)*
- `npm test` *(fails: `Cannot find module 'morphdom'`)*

------
https://chatgpt.com/codex/tasks/task_e_68417c7d2e208325b7f76559b4b2b953